### PR TITLE
식당 카프카 메시지 소비 및 총 평점 계산

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ ext {
 }
 
 dependencies {
+    // Kafka
+    implementation 'org.apache.kafka:kafka-clients:3.5.1'
+    implementation 'org.springframework.kafka:spring-kafka'
+
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/src/main/java/com/qring/restaurant/application/v1/message/kafka/KafkaMessageProducerV1.java
+++ b/src/main/java/com/qring/restaurant/application/v1/message/kafka/KafkaMessageProducerV1.java
@@ -1,0 +1,4 @@
+package com.qring.restaurant.application.v1.message.kafka;
+
+public interface KafkaMessageProducerV1 {
+}

--- a/src/main/java/com/qring/restaurant/application/v1/message/kafka/KafkaMessageProducerV1.java
+++ b/src/main/java/com/qring/restaurant/application/v1/message/kafka/KafkaMessageProducerV1.java
@@ -1,4 +1,0 @@
-package com.qring.restaurant.application.v1.message.kafka;
-
-public interface KafkaMessageProducerV1 {
-}

--- a/src/main/java/com/qring/restaurant/application/v1/res/RestaurantGetByIdResDTOV1.java
+++ b/src/main/java/com/qring/restaurant/application/v1/res/RestaurantGetByIdResDTOV1.java
@@ -48,10 +48,15 @@ public class RestaurantGetByIdResDTOV1 {
                     .tel(restaurantEntity.getTel())
                     .address(restaurantEntity.getAddress())
                     .addressDetails(restaurantEntity.getAddressDetails())
-                    .ratingAverage(restaurantEntity.getRatingAverage())
+                    .ratingAverage(roundToOneDecimalPlace(restaurantEntity.getRatingAverage()))
                     .operationStatus(restaurantEntity.getOperationStatus().getDescription())
                     .operatingHourList(OperatingHour.from(restaurantEntity.getOperatingHourEntityList()))
                     .build();
+        }
+
+        // 소수점 한 자리까지 반올림 처리
+        private static double roundToOneDecimalPlace(double value) {
+            return Math.round(value * 10) / 10.0;
         }
 
         @Getter

--- a/src/main/java/com/qring/restaurant/application/v1/res/RestaurantSearchResDTOV1.java
+++ b/src/main/java/com/qring/restaurant/application/v1/res/RestaurantSearchResDTOV1.java
@@ -68,9 +68,14 @@ public class RestaurantSearchResDTOV1 {
                         .tel(restaurantEntity.getTel())
                         .address(restaurantEntity.getAddress())
                         .addressDetails(restaurantEntity.getAddressDetails())
-                        .ratingAverage(restaurantEntity.getRatingAverage())
+                        .ratingAverage(roundToOneDecimalPlace(restaurantEntity.getRatingAverage()))
                         .operationStatus(restaurantEntity.getOperationStatus().getDescription())
                         .build();
+            }
+
+            // 소수점 한 자리까지 반올림 처리
+            private static double roundToOneDecimalPlace(double value) {
+                return Math.round(value * 10) / 10.0;
             }
         }
 

--- a/src/main/java/com/qring/restaurant/application/v1/service/RestaurantServiceV1.java
+++ b/src/main/java/com/qring/restaurant/application/v1/service/RestaurantServiceV1.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -104,20 +105,29 @@ public class RestaurantServiceV1 {
         CategoryEntity category = categoryRepository.findByIdAndDeletedAtIsNull(dto.getRestaurant().getCategoryId())
                 .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
 
-        // 5. 기존 운영 시간 삭제 처리
-        existingRestaurant.getOperatingHourEntityList()
+        // 5. 수정할 요일에 해당하는 기존 운영 시간만 삭제 처리
+        Set<String> newOperationDays = dto.getOperatingHourList().stream()
+                .map(PutRestaurantReqDTOV1.OperatingHour::getOperationDayOfWeek) // DTO 내부 클래스 활용
+                .collect(Collectors.toSet());
+
+        existingRestaurant.getOperatingHourEntityList().stream()
+                .filter(hour -> newOperationDays.contains(hour.getOperationDayOfWeek()))
                 .forEach(hour -> hour.deleteOperatingHourEntity(PassportUtil.getUsername(passport)));
 
         // 6. 새로운 운영 시간 추가
-        List<OperatingHourEntity> newOperatingHours = dto.getOperatingHourList().stream()
-                .map(newHour -> OperatingHourEntity.builder()
-                        .operationDayOfWeek(newHour.getOperationDayOfWeek())
-                        .openAt(newHour.getOpenAt())
-                        .closedAt(newHour.getClosedAt())
-                        .username(PassportUtil.getUsername(passport))
-                        .build())
-                .toList();
+        Map<String, OperatingHourEntity> newOperatingHoursMap = dto.getOperatingHourList().stream()
+                .collect(Collectors.toMap(
+                        PutRestaurantReqDTOV1.OperatingHour::getOperationDayOfWeek,
+                        newHour -> OperatingHourEntity.builder()
+                                .operationDayOfWeek(newHour.getOperationDayOfWeek())
+                                .openAt(newHour.getOpenAt())
+                                .closedAt(newHour.getClosedAt())
+                                .username(PassportUtil.getUsername(passport))
+                                .build(),
+                        (existing, replacement) -> replacement // 중복 처리 시 최신 값 유지
+                ));
 
+        List<OperatingHourEntity> newOperatingHours = new ArrayList<>(newOperatingHoursMap.values());
         existingRestaurant.addOperatingHour(newOperatingHours);
 
         // 7. 운영 상태 재계산

--- a/src/main/java/com/qring/restaurant/domain/model/RestaurantEntity.java
+++ b/src/main/java/com/qring/restaurant/domain/model/RestaurantEntity.java
@@ -169,4 +169,15 @@ public class RestaurantEntity {
     public void updateOperationStatus(OperationStatus newStatus) {
         this.operationStatus = newStatus;
     }
+
+    // 식당의 평점 관련 필드 업데이트 메서드
+    public void updateRatingAverage(double newRatingAverage) {
+        this.ratingAverage = newRatingAverage;
+    }
+
+    // modifiedBy 필드 업데이트 메서드
+    public void updateModifiedBy(String username) {
+        this.modifiedBy = username;
+    }
+
 }

--- a/src/main/java/com/qring/restaurant/domain/repository/RestaurantRepository.java
+++ b/src/main/java/com/qring/restaurant/domain/repository/RestaurantRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 
 public interface RestaurantRepository {
 
-    // 특정 ID로 삭제되지 않은 식당 존재 여부 확인
-    boolean existsByIdAndDeletedAtIsNull(Long id);
 
     // 특정 ID로 삭제되지 않은 식당과 운영시간 조회
     Optional<RestaurantEntity> findByIdWithOperatingHours(Long id);

--- a/src/main/java/com/qring/restaurant/infrastructure/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/config/KafkaConsumerConfig.java
@@ -24,7 +24,7 @@ public class KafkaConsumerConfig {
     public ConsumerFactory<String, Object> consumerFactory() {
         Map<String, Object> configProps = new HashMap<>();
         // Kafka 브로커 설정
-        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         // 직렬화/역직렬화 설정
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);

--- a/src/main/java/com/qring/restaurant/infrastructure/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,38 @@
+package com.qring.restaurant.infrastructure.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        return factory;
+    }
+}

--- a/src/main/java/com/qring/restaurant/infrastructure/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/config/KafkaConsumerConfig.java
@@ -2,6 +2,7 @@ package com.qring.restaurant.infrastructure.config;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -16,11 +17,14 @@ import java.util.Map;
 @Configuration
 public class KafkaConsumerConfig {
 
+    @Value("${KAFKA-BOOTSTRAP-SERVERS}")
+    private String bootstrapServers;
+
     @Bean
     public ConsumerFactory<String, Object> consumerFactory() {
         Map<String, Object> configProps = new HashMap<>();
         // Kafka 브로커 설정
-        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         // 직렬화/역직렬화 설정
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);

--- a/src/main/java/com/qring/restaurant/infrastructure/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/config/KafkaConsumerConfig.java
@@ -18,9 +18,10 @@ public class KafkaConsumerConfig {
 
     @Bean
     public ConsumerFactory<String, Object> consumerFactory() {
-
         Map<String, Object> configProps = new HashMap<>();
+        // Kafka 브로커 설정
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        // 직렬화/역직렬화 설정
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 
@@ -29,10 +30,8 @@ public class KafkaConsumerConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
-
         ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
-
         return factory;
     }
 }

--- a/src/main/java/com/qring/restaurant/infrastructure/messaging/dto/ReviewEventDTOV1.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/messaging/dto/ReviewEventDTOV1.java
@@ -17,7 +17,6 @@ public class ReviewEventDTOV1 {
     private int totalRating;
     private String eventType; // "CREATE", "UPDATE", "DELETE" 등
 
-    // from 메서드 추가 (유틸리티로 DTO 생성)
     public static ReviewEventDTOV1 from(Long restaurantId, int rating, int reviewCount, int totalRating, String eventType) {
         return ReviewEventDTOV1.builder()
                 .restaurantId(restaurantId)

--- a/src/main/java/com/qring/restaurant/infrastructure/messaging/dto/ReviewEventDTOV1.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/messaging/dto/ReviewEventDTOV1.java
@@ -1,4 +1,14 @@
 package com.qring.restaurant.infrastructure.messaging.dto;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class ReviewEventDTOV1 {
+    private Long restaurantId;
+    private int rating;
+    private int reviewCount;
+    private int totalRating;
+    private String eventType; // "CREATE", "UPDATE", "DELETE" 등
 }

--- a/src/main/java/com/qring/restaurant/infrastructure/messaging/dto/ReviewEventDTOV1.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/messaging/dto/ReviewEventDTOV1.java
@@ -1,0 +1,4 @@
+package com.qring.restaurant.infrastructure.messaging.dto;
+
+public class ReviewEventDTOV1 {
+}

--- a/src/main/java/com/qring/restaurant/infrastructure/messaging/dto/ReviewEventDTOV1.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/messaging/dto/ReviewEventDTOV1.java
@@ -1,14 +1,30 @@
 package com.qring.restaurant.infrastructure.messaging.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReviewEventDTOV1 {
+
     private Long restaurantId;
     private int rating;
     private int reviewCount;
     private int totalRating;
     private String eventType; // "CREATE", "UPDATE", "DELETE" 등
+
+    // from 메서드 추가 (유틸리티로 DTO 생성)
+    public static ReviewEventDTOV1 from(Long restaurantId, int rating, int reviewCount, int totalRating, String eventType) {
+        return ReviewEventDTOV1.builder()
+                .restaurantId(restaurantId)
+                .rating(rating)
+                .reviewCount(reviewCount)
+                .totalRating(totalRating)
+                .eventType(eventType)
+                .build();
+    }
 }

--- a/src/main/java/com/qring/restaurant/infrastructure/messaging/kafka/KafkaMessageConsumerV1.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/messaging/kafka/KafkaMessageConsumerV1.java
@@ -25,21 +25,26 @@ public class KafkaMessageConsumerV1 {
     @Transactional
     public void consumeReviewEvent(String message) {
         try {
-            // JSON 메시지를 ReviewEventDTOV1 객체로 변환
+            // JSON 메시지를 DTO로 변환
             ReviewEventDTOV1 reviewEvent = objectMapper.readValue(message, ReviewEventDTOV1.class);
 
             log.info("리뷰 이벤트 수신 성공: {}", reviewEvent);
 
-            if ("CREATE".equalsIgnoreCase(reviewEvent.getEventType())) {
-                updateRestaurantRating(reviewEvent);
+            switch (reviewEvent.getEventType().toUpperCase()) {
+                case "CREATE":
+                case "UPDATE":
+                    updateRestaurantRating(reviewEvent);
+                    break;
+                case "DELETE":
+                    handleDeleteEvent(reviewEvent);
+                    break;
+                default:
+                    log.warn("알 수 없는 이벤트 타입: {}", reviewEvent.getEventType());
             }
-
-            // 다른 이벤트 타입 처리 가능 (예: UPDATE, DELETE)
         } catch (Exception e) {
             log.error("리뷰 이벤트 처리 실패: {}", message, e);
         }
     }
-
 
     private void updateRestaurantRating(ReviewEventDTOV1 reviewEvent) {
         RestaurantEntity restaurant = restaurantRepository.findByIdAndDeletedAtIsNull(reviewEvent.getRestaurantId())
@@ -52,5 +57,22 @@ public class KafkaMessageConsumerV1 {
         restaurant.updateModifiedBy("system");
 
         log.info("레스토랑 ID {}의 평점이 업데이트되었습니다: {}", restaurant.getId(), newRatingAverage);
+    }
+
+    private void handleDeleteEvent(ReviewEventDTOV1 reviewEvent) {
+        RestaurantEntity restaurant = restaurantRepository.findByIdAndDeletedAtIsNull(reviewEvent.getRestaurantId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 레스토랑을 찾을 수 없습니다: " + reviewEvent.getRestaurantId()));
+
+        // 리뷰 개수가 0이면 평점을 0으로 설정
+        if (reviewEvent.getReviewCount() == 0) {
+            restaurant.updateRatingAverage(0.0);
+        } else {
+            // DELETE 이벤트라도 총 리뷰와 평점이 있을 경우 평균 계산 가능
+            double newRatingAverage = (double) reviewEvent.getTotalRating() / reviewEvent.getReviewCount();
+            restaurant.updateRatingAverage(newRatingAverage);
+        }
+
+        restaurant.updateModifiedBy("system");
+        log.info("레스토랑 ID {}의 평점이 업데이트되었습니다: {}", restaurant.getId(), restaurant.getRatingAverage());
     }
 }

--- a/src/main/java/com/qring/restaurant/infrastructure/messaging/kafka/KafkaMessageConsumerV1.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/messaging/kafka/KafkaMessageConsumerV1.java
@@ -1,13 +1,56 @@
 package com.qring.restaurant.infrastructure.messaging.kafka;
 
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qring.restaurant.domain.model.RestaurantEntity;
+import com.qring.restaurant.domain.repository.RestaurantRepository;
+import com.qring.restaurant.infrastructure.messaging.dto.ReviewEventDTOV1;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j(topic = "KafkaMessageConsumerV1 Log")
 public class KafkaMessageConsumerV1 {
 
+    private final RestaurantRepository restaurantRepository;
+
+    // JSON 문자열을 DTO로 변환하기 위한 Jackson ObjectMapper
+    private final ObjectMapper objectMapper;
+
+
+    @KafkaListener(topics = "review-event-topic", groupId = "restaurant-service")
+    @Transactional
+    public void consumeReviewEvent(String message) {
+        try {
+            // JSON 메시지를 ReviewEventDTOV1 객체로 변환
+            ReviewEventDTOV1 reviewEvent = objectMapper.readValue(message, ReviewEventDTOV1.class);
+
+            log.info("리뷰 이벤트 수신 성공: {}", reviewEvent);
+
+            if ("CREATE".equalsIgnoreCase(reviewEvent.getEventType())) {
+                updateRestaurantRating(reviewEvent);
+            }
+
+            // 다른 이벤트 타입 처리 가능 (예: UPDATE, DELETE)
+        } catch (Exception e) {
+            log.error("리뷰 이벤트 처리 실패: {}", message, e);
+        }
+    }
+
+
+    private void updateRestaurantRating(ReviewEventDTOV1 reviewEvent) {
+        RestaurantEntity restaurant = restaurantRepository.findByIdAndDeletedAtIsNull(reviewEvent.getRestaurantId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 레스토랑을 찾을 수 없습니다: " + reviewEvent.getRestaurantId()));
+
+        double newRatingAverage = (double) reviewEvent.getTotalRating() / reviewEvent.getReviewCount();
+
+        restaurant.updateRatingAverage(newRatingAverage);
+
+        restaurant.updateModifiedBy("system");
+
+        log.info("레스토랑 ID {}의 평점이 업데이트되었습니다: {}", restaurant.getId(), newRatingAverage);
+    }
 }

--- a/src/main/java/com/qring/restaurant/infrastructure/messaging/kafka/KafkaMessageConsumerV1.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/messaging/kafka/KafkaMessageConsumerV1.java
@@ -1,0 +1,13 @@
+package com.qring.restaurant.infrastructure.messaging.kafka;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "KafkaMessageConsumerV1 Log")
+public class KafkaMessageConsumerV1 {
+
+}

--- a/src/main/java/com/qring/restaurant/infrastructure/repository/JpaRestaurantRepository.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/repository/JpaRestaurantRepository.java
@@ -10,8 +10,6 @@ import java.util.Optional;
 
 public interface JpaRestaurantRepository extends JpaRepository<RestaurantEntity, Long> {
 
-    // 특정 ID로 삭제되지 않은 식당 존재 여부 확인
-    boolean existsByIdAndDeletedAtIsNull(Long id);
 
     // 특정 ID로 삭제되지 않은 식당과 운영시간 조회
     @Query("SELECT r FROM RestaurantEntity r LEFT JOIN FETCH r.operatingHourEntityList WHERE r.id = :id AND r.deletedAt IS NULL")

--- a/src/main/java/com/qring/restaurant/infrastructure/repository/JpaRestaurantRepository.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/repository/JpaRestaurantRepository.java
@@ -2,6 +2,7 @@ package com.qring.restaurant.infrastructure.repository;
 
 import com.qring.restaurant.domain.model.RestaurantEntity;
 import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,7 +13,12 @@ public interface JpaRestaurantRepository extends JpaRepository<RestaurantEntity,
 
 
     // 특정 ID로 삭제되지 않은 식당과 운영시간 조회
-    @Query("SELECT r FROM RestaurantEntity r LEFT JOIN FETCH r.operatingHourEntityList WHERE r.id = :id AND r.deletedAt IS NULL")
+    @EntityGraph(attributePaths = {"operatingHourEntityList"})
+    @Query("SELECT r FROM RestaurantEntity r " +
+            "LEFT JOIN FETCH r.operatingHourEntityList oh " +
+            "WHERE r.id = :id " +
+            "AND r.deletedAt IS NULL " +
+            "AND (oh.deletedAt IS NULL OR oh.id IS NULL)")
     Optional<RestaurantEntity> findByIdWithOperatingHours(@Param("id") Long id);
 
     // 특정 ID로 삭제되지 않은 식당 조회

--- a/src/main/java/com/qring/restaurant/infrastructure/repository/RestaurantQueryRepository.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/repository/RestaurantQueryRepository.java
@@ -76,6 +76,9 @@ public class RestaurantQueryRepository {
 
 
     private OrderSpecifier<?> getOrderSpecifier(String sort) {
+        if(sort == null || sort.isBlank()){
+            return restaurantEntity.createdAt.desc(); // 기본값
+        }
         switch (sort.toLowerCase()) {
             case "high":
                 return restaurantEntity.ratingAverage.desc();

--- a/src/main/java/com/qring/restaurant/infrastructure/repository/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/repository/RestaurantRepositoryImpl.java
@@ -22,11 +22,6 @@ public class RestaurantRepositoryImpl implements RestaurantRepository {
     private final RestaurantQueryRepository restaurantQueryRepository;
 
     @Override
-    public boolean existsByIdAndDeletedAtIsNull(Long id) {
-        return jpaRestaurantRepository.existsByIdAndDeletedAtIsNull(id);
-    }
-
-    @Override
     public Optional<RestaurantEntity> findByIdAndDeletedAtIsNull(Long id) {
         return jpaRestaurantRepository.findByIdAndDeletedAtIsNull(id);
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,6 +18,16 @@ spring:
   config:
     import: classpath:application-key.yml
 
+    kafka:
+      bootstrap-servers: localhost:9092
+      consumer:
+        group-id: ${spring.application.name}-group
+        auto-offset-reset: earliest
+        key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        properties:
+          spring.json.trusted.packages: '*'
+
 eureka:
   client:
     service-url:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ spring:
     import: classpath:application-key.yml
 
     kafka:
-      bootstrap-servers: localhost:9092
+      bootstrap-servers: ${KAFKA-BOOTSTRAP-SERVERS}
       consumer:
         group-id: ${spring.application.name}-group
         auto-offset-reset: earliest


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #7 

## 📝 Description

- 리뷰서비스에서 리뷰 생성 및 수정/삭제 시 평점을 카프카 메시지로 발행한 메시지를 소비 하고 총 평균 평점을 계산해서 생성, 수정을 하도록 구현 했습니다.

- 카프카 메시지 소비 (컨슈머)
  - 위치: KafkaMessageConsumerV1
  - 리뷰 서비스에서 발행한 메시지를 수신하여 해당 레스토랑의 평점 평균을 업데이트.
  
- 메시지 처리 로직
  -  `CREATE`, `UPDATE` 이벤트:
    - 총 평점과 리뷰 개수를 기반으로 평점 평균을 계산.
    - 평점 평균 업데이트.
  - `DELETE` 이벤트:
    - 리뷰 삭제 후 리뷰 개수가 `0`일 경우 평점을 `0`으로 설정.
    - 리뷰가 남아있으면 기존 로직으로 평균을 다시 계산.
    
- 소수점 처리
    - 레스토랑 평점 평균(`ratingAverage`)은 소수점 1자리까지만 반올림 처리.

## 💬 To Reivewers

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. (생략 가능)

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
