### PR TITLE
대용량 식당 데이터 조회 성능 테스트 및 페이지네이션 개선

### DIFF
--- a/src/main/java/com/qring/restaurant/application/res/RestaurantSearchResDTOV2.java
+++ b/src/main/java/com/qring/restaurant/application/res/RestaurantSearchResDTOV2.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
@@ -13,13 +13,12 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RestaurantSearchResDTOV1 {
-
+public class RestaurantSearchResDTOV2 {
     private RestaurantPage restaurantPage;
 
-    public static RestaurantSearchResDTOV1 of(Page<RestaurantEntity> restaurantEntityPage) {
-        return RestaurantSearchResDTOV1.builder()
-                .restaurantPage(RestaurantPage.from(restaurantEntityPage))
+    public static RestaurantSearchResDTOV2 of(Slice<RestaurantEntity> restaurantEntitySlice) {
+        return RestaurantSearchResDTOV2.builder()
+                .restaurantPage(RestaurantPage.from(restaurantEntitySlice))
                 .build();
     }
 
@@ -32,10 +31,10 @@ public class RestaurantSearchResDTOV1 {
         private List<Restaurant> restaurantList;
         private PageDetails page;
 
-        public static RestaurantPage from(Page<RestaurantEntity> restaurantEntityPage) {
+        public static RestaurantPage from(Slice<RestaurantEntity> restaurantEntitySlice) {
             return RestaurantPage.builder()
-                    .restaurantList(Restaurant.from(restaurantEntityPage.getContent()))
-                    .page(PageDetails.from(restaurantEntityPage))
+                    .restaurantList(Restaurant.from(restaurantEntitySlice.getContent()))
+                    .page(PageDetails.from(restaurantEntitySlice))
                     .build();
         }
 
@@ -87,15 +86,13 @@ public class RestaurantSearchResDTOV1 {
 
             private int size;
             private int number;
-            private long totalElements;
-            private int totalPages;
+            private boolean hasNext; // ✅ Slice 에서 `totalPages` 대신 사용
 
-            public static PageDetails from(Page<RestaurantEntity> restaurantEntityPage) {
+            public static PageDetails from(Slice<RestaurantEntity> restaurantEntitySlice) {
                 return PageDetails.builder()
-                        .size(restaurantEntityPage.getSize())
-                        .number(restaurantEntityPage.getNumber())
-                        .totalElements(restaurantEntityPage.getTotalElements())
-                        .totalPages(restaurantEntityPage.getTotalPages())
+                        .size(restaurantEntitySlice.getSize())
+                        .number(restaurantEntitySlice.getNumber())
+                        .hasNext(restaurantEntitySlice.hasNext()) // ✅ `hasNext` 필드 추가
                         .build();
             }
         }

--- a/src/main/java/com/qring/restaurant/application/service/RestaurantServiceV1.java
+++ b/src/main/java/com/qring/restaurant/application/service/RestaurantServiceV1.java
@@ -5,7 +5,7 @@ import com.qring.restaurant.application.global.exception.UnauthorizedAccessExcep
 import com.qring.restaurant.application.res.RestaurantGetByIdResDTOV1;
 import com.qring.restaurant.application.res.RestaurantIdTableResDTOV1;
 import com.qring.restaurant.application.res.RestaurantPostResDTOV1;
-import com.qring.restaurant.application.res.RestaurantSearchResDTOV1;
+import com.qring.restaurant.application.res.RestaurantSearchResDTOV2;
 import com.qring.restaurant.domain.model.CategoryEntity;
 import com.qring.restaurant.domain.model.OperatingHourEntity;
 import com.qring.restaurant.domain.model.RegionEntity;
@@ -18,7 +18,6 @@ import com.qring.restaurant.infrastructure.util.PassportUtil;
 import com.qring.restaurant.presentation.req.PostRestaurantReqDTOV1;
 import com.qring.restaurant.presentation.req.PutRestaurantReqDTOV1;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,8 +72,8 @@ public class RestaurantServiceV1 {
 
     // 조건에 따른 식당 검색
     @Transactional(readOnly = true)
-    public RestaurantSearchResDTOV1 searchBy(Long userId, String name, Boolean isOperation, String sort, String address, String category, Pageable pageable) {
-        return RestaurantSearchResDTOV1.of(restaurantRepository.findRestaurantPageByDeletedAtIsNullWithConditions(userId, name, isOperation, sort, address, category, pageable));
+    public RestaurantSearchResDTOV2 searchBy(Long userId, String name, Boolean isOperation, String sort, String address, String category, Long cursor, int limit) {
+        return RestaurantSearchResDTOV2.of(restaurantRepository.findRestaurantPageByDeletedAtIsNullWithConditions(userId, name, isOperation, sort, address, category, cursor, limit));
     }
 
     // 식당 상세 조회

--- a/src/main/java/com/qring/restaurant/domain/repository/RestaurantRepository.java
+++ b/src/main/java/com/qring/restaurant/domain/repository/RestaurantRepository.java
@@ -1,8 +1,7 @@
 package com.qring.restaurant.domain.repository;
 
 import com.qring.restaurant.domain.model.RestaurantEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +12,7 @@ public interface RestaurantRepository {
     Optional<RestaurantEntity> findByIdAndDeletedAtIsNull(Long id);
 
     // 조건에 따른 식당 검색
-    Page<RestaurantEntity> findRestaurantPageByDeletedAtIsNullWithConditions(Long userId, String name, Boolean isOperation, String sort, String address, String category, Pageable pageable);
+    Slice<RestaurantEntity> findRestaurantPageByDeletedAtIsNullWithConditions(Long userId, String name, Boolean isOperation, String sort, String address, String category, Long cursor, int limit);
 
     // 식당 저장
     RestaurantEntity save(RestaurantEntity restaurantEntity);

--- a/src/main/java/com/qring/restaurant/infrastructure/docs/RestaurantControllerSwagger.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/docs/RestaurantControllerSwagger.java
@@ -5,7 +5,7 @@ import com.qring.restaurant.application.global.dto.ResDTO;
 import com.qring.restaurant.application.res.RestaurantGetByIdResDTOV1;
 import com.qring.restaurant.application.res.RestaurantIdTableResDTOV1;
 import com.qring.restaurant.application.res.RestaurantPostResDTOV1;
-import com.qring.restaurant.application.res.RestaurantSearchResDTOV1;
+import com.qring.restaurant.application.res.RestaurantSearchResDTOV2;
 import com.qring.restaurant.presentation.req.PostRestaurantReqDTOV1;
 import com.qring.restaurant.presentation.req.PutRestaurantReqDTOV1;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,9 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,13 +38,14 @@ public interface RestaurantControllerSwagger {
             @ApiResponse(responseCode = "400", description = "식상 검색 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
     @GetMapping
-    ResponseEntity<ResDTO<RestaurantSearchResDTOV1>> searchBy(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-                                                              @RequestParam(name = "userId", required = false) Long userId,
-                                                              @RequestParam(name = "name", required = false) String name,
-                                                              @RequestParam(name = "isOperation", required = false) Boolean isOperation,
-                                                              @RequestParam(name = "sort", required = false) String sort,
-                                                              @RequestParam(name = "address", required = false) String address,
-                                                              @RequestParam(name = "category", required = false) String category);
+    ResponseEntity<ResDTO<RestaurantSearchResDTOV2>> searchBy(@RequestParam(name = "userId", required = false) Long userId,
+                                                                     @RequestParam(name = "name", required = false) String name,
+                                                                     @RequestParam(name = "isOperation", required = false) Boolean isOperation,
+                                                                     @RequestParam(name = "sort", required = false) String sort,
+                                                                     @RequestParam(name = "address", required = false) String address,
+                                                                     @RequestParam(name = "category", required = false) String category,
+                                                                     @RequestParam(name = "cursor", required = false) Long cursor,
+                                                                     @RequestParam(name = "limit", required = false, defaultValue = "10") int limit);
 
 
     @Operation(summary = "식당 상세 조회", description = "식당을 상세 조회하는 API 입니다.")

--- a/src/main/java/com/qring/restaurant/infrastructure/repository/restaurant/RestaurantQueryRepository.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/repository/restaurant/RestaurantQueryRepository.java
@@ -5,12 +5,9 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Repository;
 
 import java.time.DayOfWeek;
@@ -27,46 +24,38 @@ public class RestaurantQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    // 조건에 따른 식당 검색
-    public Page<RestaurantEntity> findRestaurantPageByDeletedAtIsNullWithConditions(
-            Long userId, String name, Boolean isOperation, String sort, String address, String category, Pageable pageable) {
+    // 커서 기반 페이지네이션 적용
+    public Slice<RestaurantEntity> findRestaurantPageByDeletedAtIsNullWithConditions(
+            Long userId, String name, Boolean isOperation, String sort, String address, String category, Long cursor, int limit) {
 
         LocalTime now = LocalTime.now();
         DayOfWeek today = LocalDate.now().getDayOfWeek();
 
-        // 조건에 맞는 결과 조회
         List<RestaurantEntity> results = queryFactory
                 .selectFrom(restaurantEntity)
+                .join(restaurantEntity.region).fetchJoin()
+                .join(restaurantEntity.category).fetchJoin()
                 .where(
                         restaurantEntity.deletedAt.isNull(),
                         userIdEq(userId),
                         categoryIdEq(category),
                         nameLike(name),
                         addressLike(address),
-                        isOperationEq(isOperation, today, now)
+                        isOperationEq(isOperation, today, now),
+                        cursorIdLoe(cursor)
                 )
                 .orderBy(getOrderSpecifier(sort))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(limit + 1) // 다음 페이지 존재 여부 확인을 위해 limit보다 1개 더 조회
                 .fetch();
 
-        // 총 개수 조회
-        JPQLQuery<Long> countQuery = queryFactory
-                .select(restaurantEntity.count())
-                .from(restaurantEntity)
-                .where(
-                        restaurantEntity.deletedAt.isNull(),
-                        userIdEq(userId),
-                        categoryIdEq(category),
-                        nameLike(name),
-                        addressLike(address),
-                        isOperationEq(isOperation, today, now)
-                );
+        // 다음 페이지 존재 여부 확인
+        boolean hasNext = results.size() > limit;
+        if (hasNext) {
+            results.remove(results.size() - 1); // 초과한 1개 제거
+        }
 
-        // Page 반환
-        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+        return new SliceImpl<>(results, PageRequest.of(0, limit), hasNext);
     }
-
 
     // 조건 메서드들
     private BooleanExpression userIdEq(Long userId) {
@@ -106,10 +95,15 @@ public class RestaurantQueryRepository {
         return address != null ? restaurantEntity.address.containsIgnoreCase(address) : null;
     }
 
+    private BooleanExpression cursorIdLoe(Long cursor) {
+        return cursor != null ? restaurantEntity.id.loe(cursor) : null;
+    }
+
     private OrderSpecifier<?> getOrderSpecifier(String sort) {
         if (sort == null || sort.isBlank()) {
-            return restaurantEntity.createdAt.desc(); // 기본값: 생성일 내림차순 정렬
+            return restaurantEntity.id.desc();
         }
+
         switch (sort.toLowerCase()) {
             case "high":
                 // 리뷰 평균 점수 높은 순 정렬

--- a/src/main/java/com/qring/restaurant/infrastructure/repository/restaurant/RestaurantQueryRepository.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/repository/restaurant/RestaurantQueryRepository.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.qring.restaurant.domain.model.QOperatingHourEntity.operatingHourEntity;
@@ -42,9 +43,9 @@ public class RestaurantQueryRepository {
                         nameLike(name),
                         addressLike(address),
                         isOperationEq(isOperation, today, now),
-                        cursorIdLoe(cursor)
+                        cursorPagination(cursor, sort)
                 )
-                .orderBy(getOrderSpecifier(sort))
+                .orderBy(getOrderSpecifiers(sort).toArray(new OrderSpecifier<?>[0]))
                 .limit(limit + 1) // 다음 페이지 존재 여부 확인을 위해 limit보다 1개 더 조회
                 .fetch();
 
@@ -95,38 +96,43 @@ public class RestaurantQueryRepository {
         return address != null ? restaurantEntity.address.containsIgnoreCase(address) : null;
     }
 
-    private BooleanExpression cursorIdLoe(Long cursor) {
-        return cursor != null ? restaurantEntity.id.loe(cursor) : null;
+    private BooleanExpression cursorPagination(Long cursor, String sort) {
+        if (cursor == null) {
+            return null;
+        }
+
+        boolean isOldest = sort != null && sort.toLowerCase().contains("oldest");
+
+        return isOldest ? restaurantEntity.id.goe(cursor) : restaurantEntity.id.loe(cursor);
     }
 
-    private OrderSpecifier<?> getOrderSpecifier(String sort) {
-        if (sort == null || sort.isBlank()) {
-            return restaurantEntity.id.desc();
+    private List<OrderSpecifier<?>> getOrderSpecifiers(String sort) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        boolean isOldest = sort != null && sort.toLowerCase().contains("oldest");
+
+        if (sort != null) {
+            if (sort.toLowerCase().contains("high")) {
+                // 평점 높은 순 정렬
+                orders.add(Expressions.numberTemplate(Double.class,
+                        "case when {0} > 0 then {1} / {0} else 0 end",
+                        restaurantEntity.reviewCount,
+                        restaurantEntity.totalRating
+                ).desc().nullsLast());
+            } else if (sort.toLowerCase().contains("low")) {
+                // 평점 낮은 순 정렬
+                orders.add(Expressions.numberTemplate(Double.class,
+                        "case when {0} > 0 then {1} / {0} else 0 end",
+                        restaurantEntity.reviewCount,
+                        restaurantEntity.totalRating
+                ).asc().nullsLast());
+            }
         }
 
-        switch (sort.toLowerCase()) {
-            case "high":
-                // 리뷰 평균 점수 높은 순 정렬
-                return Expressions.numberTemplate(Double.class,
-                        // SQL CASE 구문과 유사: reviewCount > 0이면 totalRating / reviewCount, 아니면 0 반환
-                        "case when {0} > 0 then {1} / {0} else 0 end",
-                        restaurantEntity.reviewCount,
-                        restaurantEntity.totalRating
-                ).desc(); // 내림차순 정렬
-            case "low":
-                // 리뷰 평균 점수 낮은 순 정렬
-                return Expressions.numberTemplate(Double.class,
-                        "case when {0} > 0 then {1} / {0} else 0 end",
-                        restaurantEntity.reviewCount,
-                        restaurantEntity.totalRating
-                ).asc(); // 오름차순 정렬
-            case "oldest":
-                // 오래된 순(생성일 오름차순) 정렬
-                return restaurantEntity.createdAt.asc();
-            default:
-                // 기본값: 최신 순(생성일 내림차순) 정렬
-                return restaurantEntity.createdAt.desc();
-        }
+        // 최신순 또는 오래된순 정렬 적용
+        orders.add(isOldest ? restaurantEntity.id.asc() : restaurantEntity.id.desc());
+
+        return orders;
     }
 
     private String getOperationDayOfWeek(DayOfWeek dayOfWeek) {

--- a/src/main/java/com/qring/restaurant/infrastructure/repository/restaurant/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/qring/restaurant/infrastructure/repository/restaurant/RestaurantRepositoryImpl.java
@@ -3,8 +3,7 @@ package com.qring.restaurant.infrastructure.repository.restaurant;
 import com.qring.restaurant.domain.model.RestaurantEntity;
 import com.qring.restaurant.domain.repository.RestaurantRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,8 +22,8 @@ public class RestaurantRepositoryImpl implements RestaurantRepository {
     }
 
     @Override
-    public Page<RestaurantEntity> findRestaurantPageByDeletedAtIsNullWithConditions(Long userId, String name, Boolean isOperation, String sort, String address, String category, Pageable pageable) {
-        return restaurantQueryRepository.findRestaurantPageByDeletedAtIsNullWithConditions(userId, name, isOperation, sort, address, category, pageable);
+    public Slice<RestaurantEntity> findRestaurantPageByDeletedAtIsNullWithConditions(Long userId, String name, Boolean isOperation, String sort, String address, String category, Long cursor, int limit) {
+        return restaurantQueryRepository.findRestaurantPageByDeletedAtIsNullWithConditions(userId, name, isOperation, sort, address, category, cursor, limit);
     }
 
     @Override

--- a/src/main/java/com/qring/restaurant/presentation/controller/RestaurantControllerV1.java
+++ b/src/main/java/com/qring/restaurant/presentation/controller/RestaurantControllerV1.java
@@ -4,14 +4,13 @@ import com.qring.restaurant.application.global.dto.ResDTO;
 import com.qring.restaurant.application.res.RestaurantGetByIdResDTOV1;
 import com.qring.restaurant.application.res.RestaurantIdTableResDTOV1;
 import com.qring.restaurant.application.res.RestaurantPostResDTOV1;
-import com.qring.restaurant.application.res.RestaurantSearchResDTOV1;
+import com.qring.restaurant.application.res.RestaurantSearchResDTOV2;
 import com.qring.restaurant.application.service.RestaurantServiceV1;
 import com.qring.restaurant.infrastructure.docs.RestaurantControllerSwagger;
 import com.qring.restaurant.presentation.req.PostRestaurantReqDTOV1;
 import com.qring.restaurant.presentation.req.PutRestaurantReqDTOV1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -39,22 +38,24 @@ public class RestaurantControllerV1 implements RestaurantControllerSwagger {
 
     // 식당 검색
     @GetMapping
-    public ResponseEntity<ResDTO<RestaurantSearchResDTOV1>> searchBy(Pageable pageable,
-                                                                     @RequestParam(name = "userId", required = false) Long userId,
+    public ResponseEntity<ResDTO<RestaurantSearchResDTOV2>> searchBy(@RequestParam(name = "userId", required = false) Long userId,
                                                                      @RequestParam(name = "name", required = false) String name,
                                                                      @RequestParam(name = "isOperation", required = false) Boolean isOperation,
                                                                      @RequestParam(name = "sort", required = false) String sort,
                                                                      @RequestParam(name = "address", required = false) String address,
-                                                                     @RequestParam(name = "category", required = false) String category) {
-        return new ResponseEntity<>(
-                ResDTO.<RestaurantSearchResDTOV1>builder()
+                                                                     @RequestParam(name = "category", required = false) String category,
+                                                                     @RequestParam(name = "cursor", required = false) Long cursor,
+                                                                     @RequestParam(name = "limit", required = false, defaultValue = "10") int limit) {
+
+        return ResponseEntity.ok(
+                ResDTO.<RestaurantSearchResDTOV2>builder()
                         .code(HttpStatus.OK.value())
                         .message("식당 검색에 성공하였습니다.")
-                        .data(restaurantServiceV1.searchBy(userId, name, isOperation, sort, address, category, pageable))
-                        .build(),
-                HttpStatus.OK
+                        .data(restaurantServiceV1.searchBy(userId, name, isOperation, sort, address, category, cursor, limit))
+                        .build()
         );
     }
+
 
     // 식당 상세 조회
     @GetMapping("/{id}")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #27 

## 📝 Description

- 기존 오프셋 기반 페이지네이션에서 데이터가 증가함에 따라 성능 저하가 발생하는 문제를 발견하였습니다.
- 이를 해결하기 위해 커서 기반 페이지네이션 기법을 적용하였습니다.
- 평점 순 정렬 시 기본적으로 최신순으로 정렬되도록 수정하였으며,
- 평점 순 정렬을 할 때 추가적으로 오래된 순 정렬 옵션도 선택할 수 있도록 개선하였습니다.

### `Offset-based Pagination` 문제 상황

건수 | 평균 응답 시간 (s) | 증감률 (%)
-- | -- | --
10만 | 0.10 | -
100만 | 0.19 | 81.36
200만 | 0.23 | 21.52
300만 | 0.29 | 26.60
400만 | 0.44 | 51.94
500만 | 0.53 | 19.14
600만 | 0.57 | 8.75
700만 | 0.72 | 25.01
800만 | 1.05 | 46.11
900만 | 1.47 | 40.38
1,000만 | 1.64 | 11.22

- 데이터가 증가함에 따라 평균 응답 시간이 점점 늘어나는 것을 확인할 수 있습니다.

### Offset-based vs Cursor-based 성능 비교

Pagination Type | 데이터 크기 | 평균 응답 시간(s) | 개선률 (%)
-- | -- | -- | --
Offset-based | 10,000,000 건 | 1.64 | -
Cursor-based | 10,000,000 건 | 0.03 | 98.18

- 로컬 환경에서 평균 1.64초였던 조회 속도를 0.03초로 단축하여 **98.18%** 성능 개선을 이뤄냈습니다.

### 정렬 쿼리 수정
#### 개선 전
```java
    private OrderSpecifier<?> getOrderSpecifier(String sort) {
        if (sort == null || sort.isBlank()) {
            return restaurantEntity.id.desc();
        }

        switch (sort.toLowerCase()) {
            case "high":
                // 리뷰 평균 점수 높은 순 정렬
                return Expressions.numberTemplate(Double.class,
                        // SQL CASE 구문과 유사: reviewCount > 0이면 totalRating / reviewCount, 아니면 0 반환
                        "case when {0} > 0 then {1} / {0} else 0 end",
                        restaurantEntity.reviewCount,
                        restaurantEntity.totalRating
                ).desc(); // 내림차순 정렬
            case "low":
                // 리뷰 평균 점수 낮은 순 정렬
                return Expressions.numberTemplate(Double.class,
                        "case when {0} > 0 then {1} / {0} else 0 end",
                        restaurantEntity.reviewCount,
                        restaurantEntity.totalRating
                ).asc(); // 오름차순 정렬
            case "oldest":
                // 오래된 순(생성일 오름차순) 정렬
                return restaurantEntity.createdAt.asc();
            default:
                // 기본값: 최신 순(생성일 내림차순) 정렬
                return restaurantEntity.createdAt.desc();
        }
    }
```

#### 개선 후
```java
    private List<OrderSpecifier<?>> getOrderSpecifiers(String sort) {
        List<OrderSpecifier<?>> orders = new ArrayList<>();

        boolean isOldest = sort != null && sort.toLowerCase().contains("oldest");

        if (sort != null) {
            if (sort.toLowerCase().contains("high")) {
                // 평점 높은 순 정렬
                orders.add(Expressions.numberTemplate(Double.class,
                        "case when {0} > 0 then {1} / {0} else 0 end",
                        restaurantEntity.reviewCount,
                        restaurantEntity.totalRating
                ).desc().nullsLast());
            } else if (sort.toLowerCase().contains("low")) {
                // 평점 낮은 순 정렬
                orders.add(Expressions.numberTemplate(Double.class,
                        "case when {0} > 0 then {1} / {0} else 0 end",
                        restaurantEntity.reviewCount,
                        restaurantEntity.totalRating
                ).asc().nullsLast());
            }
        }

        // 최신순 또는 오래된순 정렬 적용
        orders.add(isOldest ? restaurantEntity.id.asc() : restaurantEntity.id.desc());

        return orders;
    }
```

- 개선 전에는 평점 순과 생성일 순으로 별도로 정렬할 수 있었습니다.
- 개선 후에는 평점 순과 생성일 순 정렬을 동시에 적용할 수 있도록 수정하였습니다.